### PR TITLE
Use defang URL shortener for download URL

### DIFF
--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -51,7 +51,7 @@ jobs:
         TAG_NAME=$(echo '${{ steps.latest-release.outputs.result }}' | jq -r '.tag_name')
         echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
         # Fixes FormulaAudit/Urls: Use /archive/ URLs for GitHub tarballs
-        echo "TARBALL_URL=https://github.com/DefangLabs/defang/archive/refs/tags/$TAG_NAME.tar.gz" >> $GITHUB_ENV
+        echo "TARBALL_URL=https://s.defang.io/defang_${TAG_NAME:1}_source.tar.gz?x-defang-source=homebrew" >> $GITHUB_ENV
 
     - name: Compute SHA256 checksum
       run: |

--- a/Formula/defang.rb
+++ b/Formula/defang.rb
@@ -1,7 +1,7 @@
 class Defang < Formula
   desc "Command-line interface for the Defang Opinionated Platform"
   homepage "https://defang.io"
-  url "https://github.com/DefangLabs/defang/archive/refs/tags/v0.5.40.tar.gz"
+  url "https://s.defang.io/defang_0.5.40_source.tar.gz?x-defang-source=homebrew"
   sha256 "c5cdab8ea97e2aac29171303f731e24c3fb3313e704cc17b84e8096370768d98"
   license "MIT"
   head "https://github.com/DefangLabs/defang.git", branch: "main"


### PR DESCRIPTION
Brew curl download strategy [uses "--location" (-L) flag by default](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/utils/curl.rb#L198) when downloading thus allow follow redirection