### PR TITLE
Update GitHub Actions workflows to use specific action versions

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# List of files staged for commit.
+changed=$(git diff --cached --name-only --diff-filter=ACMR)
+
+# run_if_changed <path-regex> <cmd> [args...]
+#   Runs `cmd` (extended-regex match against the staged file list).
+#   Aborts the commit if `cmd` is not on PATH.
+run_if_changed() {
+  local regex=$1
+  shift
+  grep -qE "$regex" <<<"$changed" || return 0
+  if ! command -v "$1" >/dev/null; then
+    echo "pre-commit: '$1' not on PATH. Install it (or run 'direnv allow' if using nix)." >&2
+    exit 1
+  fi
+  "$@"
+}
+
+# --- Checks ---------------------------------------------------------------
+# Add a new line per tool: trigger regex + command.
+
+run_if_changed '^\.github/(workflows|actions)/' actionlint

--- a/.github/actionlint-matcher.json
+++ b/.github/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -1,0 +1,33 @@
+name: Lint GitHub Actions
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+
+permissions:
+  contents: read
+
+jobs:
+  lint-actions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Run actionlint
+        run: |
+          echo "::add-matcher::.github/actionlint-matcher.json"
+          curl -fsSL "https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz" -o actionlint.tar.gz
+          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  actionlint.tar.gz" | sha256sum -c
+          tar xzf actionlint.tar.gz actionlint
+          ./actionlint -color
+
+      - name: Check for non-SHA-pinned actions
+        run: |
+          # Match uses: lines where @ is NOT followed by a 40-char hex SHA
+          # Ignore commented-out lines
+          if grep -rPn '^\s+uses:\s+\S+@(?![0-9a-f]{40}\b)' .github/workflows/; then
+            echo "::error::Found actions not pinned to a commit SHA. Use the full SHA with a version comment, e.g. actions/checkout@abc123...def # v6"
+            exit 1
+          fi

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Run actionlint
         run: |
@@ -27,7 +29,7 @@ jobs:
         run: |
           # Match uses: lines where @ is NOT followed by a 40-char hex SHA
           # Ignore commented-out lines
-          if grep -rPn '^\s+uses:\s+\S+@(?![0-9a-f]{40}\b)' .github/workflows/; then
+          if grep -rPn '^\s+-?\suses:\s+\S+@(?![0-9a-f]{40}\b)' .github/workflows/; then
             echo "::error::Found actions not pinned to a commit SHA. Use the full SHA with a version comment, e.g. actions/checkout@abc123...def # v6"
             exit 1
           fi

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -27,9 +27,11 @@ jobs:
 
       - name: Check for non-SHA-pinned actions
         run: |
+          paths=(.github/workflows)
+          [[ -d .github/actions ]] && paths+=(.github/actions)
           # Match uses: lines where @ is NOT followed by a 40-char hex SHA
           # Ignore commented-out lines
-          if grep -rPn '^\s+-?\suses:\s+\S+@(?![0-9a-f]{40}\b)' .github/workflows/; then
+          if grep -rPn '^\s+-?\s+uses:\s+\S+@(?![0-9a-f]{40}\b)' "${paths[@]}" ; then
             echo "::error::Found actions not pinned to a commit SHA. Use the full SHA with a version comment, e.g. actions/checkout@abc123...def # v6"
             exit 1
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
           HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.actor }}
           PULL_REQUEST: ${{ github.event.pull_request.number }}
-        run: brew pr-pull --debug --tap=$GITHUB_REPOSITORY $PULL_REQUEST
+        run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@8eb7f2efa6ab636da09aef605b497fd5b8a7587d # master
@@ -36,4 +36,4 @@ jobs:
         if: github.event.pull_request.head.repo.fork == false
         env:
           BRANCH: ${{ github.event.pull_request.head.ref }}
-        run: git push --delete origin $BRANCH
+        run: git push --delete origin "$BRANCH"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@8eb7f2efa6ab636da09aef605b497fd5b8a7587d # master
 
       - name: Set up git
-        uses: Homebrew/actions/git-user-config@master
+        uses: Homebrew/actions/git-user-config@8eb7f2efa6ab636da09aef605b497fd5b8a7587d # master
 
       - name: Pull bottles
         env:
@@ -27,7 +27,7 @@ jobs:
         run: brew pr-pull --debug --tap=$GITHUB_REPOSITORY $PULL_REQUEST
 
       - name: Push commits
-        uses: Homebrew/actions/git-try-push@master
+        uses: Homebrew/actions/git-try-push@8eb7f2efa6ab636da09aef605b497fd5b8a7587d # master
         with:
           token: ${{ github.token }}
           branch: main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@8eb7f2efa6ab636da09aef605b497fd5b8a7587d # master
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: bottles
           path: '*.bottle.*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-22.04, macos-14]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew
@@ -37,4 +37,4 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: bottles
-          path: '*.bottle.*'
+          path: "*.bottle.*"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,12 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-14]
+        os: [macos-14]
+        include:
+          - os: ubuntu-latest
+            container: ghcr.io/homebrew/brew:main
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,4 +37,4 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: bottles
-          path: '*.bottle.*'
+          path: "*.bottle.*"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: bottles
           path: '*.bottle.*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,8 +8,12 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-15]
+        os: [macos-15]
+        include:
+          - os: ubuntu-latest
+            container: ghcr.io/homebrew/brew:main
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -12,96 +12,97 @@ jobs:
   update-formula:
     runs-on: ubuntu-latest
     steps:
+      - name: Only deploy on repository_dispatch if version starts with 'v'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          VERSION: ${{ github.event.client_payload.version }}
+        run: |
+          echo "Event name: $EVENT_NAME"
+          echo "Type: $EVENT_ACTION"
+          echo "Version: $VERSION"
+          if [[ "$EVENT_NAME" == "repository_dispatch" && "$EVENT_ACTION" == "update-homebrew-formula" ]]; then
+            if [[ "$VERSION" != v* ]]; then
+              echo "Version does not start with 'v'. Stopping workflow."
+              exit 1
+            fi
+          fi
+        shell: bash
 
-    - name: Only deploy on repository_dispatch if version starts with 'v'
-      env:
-        EVENT_NAME: ${{ github.event_name }}
-        EVENT_ACTION: ${{ github.event.action }}
-        VERSION: ${{ github.event.client_payload.version }}
-      run: |
-        echo "Event name: $EVENT_NAME"
-        echo "Type: $EVENT_ACTION"
-        echo "Version: $VERSION"
-        if [[ "$EVENT_NAME" == "repository_dispatch" && "$EVENT_ACTION" == "update-homebrew-formula" ]]; then
-          if [[ "$VERSION" != v* ]]; then
-            echo "Version does not start with 'v'. Stopping workflow."
+      - name: Checkout Homebrew repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Fetch the latest release from CLI repository
+        id: latest-release
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const { data } = await github.rest.repos.getLatestRelease({
+              owner: process.env.GITHUB_REPOSITORY_OWNER,
+              repo: 'defang'
+              });
+            return {
+              tag_name: data.tag_name,
+              tarball_url: data.tarball_url
+            };
+          result-encoding: json
+
+      - name: Set environment variables for latest release
+        env:
+          LATEST_RELEASE: ${{ steps.latest-release.outputs.result }}
+        run: |
+          # [WORKAROUND] Even though the github-script output is supposed to be JSON, looks like we are getting a string
+          TAG_NAME=$(echo "$LATEST_RELEASE" | jq -r '.tag_name')
+          echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_ENV"
+          # Fixes FormulaAudit/Urls: Use /archive/ URLs for GitHub tarballs
+          echo "TARBALL_URL=https://github.com/DefangLabs/defang/archive/refs/tags/$TAG_NAME.tar.gz" >> "$GITHUB_ENV"
+
+      - name: Compute SHA256 checksum
+        run: |
+          set -o pipefail
+          SHA256=$(curl -fsSL "$TARBALL_URL" | sha256sum | awk '{print $1}')
+          if [ -z "$SHA256" ]; then
+            echo "Failed to compute SHA256 for $TARBALL_URL" >&2
             exit 1
           fi
-        fi
-      shell: bash
+          echo "SHA256=$SHA256" >> "$GITHUB_ENV"
 
-    - name: Checkout Homebrew repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Determine required Go version from go.mod
+        run: |
+          set -o pipefail
+          GO_MOD_URL="https://raw.githubusercontent.com/DefangLabs/defang/$TAG_NAME/src/go.mod"
+          GO_FULL=$(curl -fsSL "$GO_MOD_URL" | awk '/^go [0-9]/{print $2; exit}')
+          if [ -z "$GO_FULL" ]; then
+            echo "Failed to parse Go version from $GO_MOD_URL" >&2
+            exit 1
+          fi
+          GO_VERSION=$(echo "$GO_FULL" | cut -d. -f1,2)
+          echo "Detected Go version in go.mod: $GO_FULL -> go@$GO_VERSION"
+          echo "GO_VERSION=$GO_VERSION" >> "$GITHUB_ENV"
 
-    - name: Fetch the latest release from CLI repository
-      id: latest-release
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
-      with:
-        script: |
-          const { data } = await github.rest.repos.getLatestRelease({
-            owner: process.env.GITHUB_REPOSITORY_OWNER,
-            repo: 'defang'
-            });
-          return {
-            tag_name: data.tag_name,
-            tarball_url: data.tarball_url
-          };
-        result-encoding: json
+      - name: Update Homebrew formula
+        run: |
+          formula_path="Formula/defang.rb"
+          sed -i.bak "s|url \".*|url \"$TARBALL_URL\"|g" $formula_path
+          sed -i.bak "s|sha256 \".*|sha256 \"$SHA256\"|g" $formula_path
+          sed -i.bak "s|depends_on \"go@[^\"]*\" => :build|depends_on \"go@$GO_VERSION\" => :build|g" $formula_path
 
-    - name: Set environment variables for latest release
-      env:
-        LATEST_RELEASE: ${{ steps.latest-release.outputs.result }}
-      run: |
-        # [WORKAROUND] Even though the github-script output is supposed to be JSON, looks like we are getting a string
-        TAG_NAME=$(echo "$LATEST_RELEASE" | jq -r '.tag_name')
-        echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_ENV"
-        # Fixes FormulaAudit/Urls: Use /archive/ URLs for GitHub tarballs
-        echo "TARBALL_URL=https://github.com/DefangLabs/defang/archive/refs/tags/$TAG_NAME.tar.gz" >> "$GITHUB_ENV"
+      - name: Commit and push changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add Formula/defang.rb
+          git commit -m "Update Homebrew formula to version $TAG_NAME"
+          git push
+          git tag "$TAG_NAME"
+          git push --tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Compute SHA256 checksum
-      run: |
-        SHA256=$(curl -fsSL "$TARBALL_URL" | sha256sum | awk '{print $1}')
-        if [ -z "$SHA256" ]; then
-          echo "Failed to compute SHA256 for $TARBALL_URL" >&2
-          exit 1
-        fi
-        echo "SHA256=$SHA256" >> "$GITHUB_ENV"
-
-    - name: Determine required Go version from go.mod
-      run: |
-        GO_MOD_URL="https://raw.githubusercontent.com/DefangLabs/defang/$TAG_NAME/src/go.mod"
-        GO_FULL=$(curl -fsSL "$GO_MOD_URL" | awk '/^go [0-9]/{print $2; exit}')
-        if [ -z "$GO_FULL" ]; then
-          echo "Failed to parse Go version from $GO_MOD_URL" >&2
-          exit 1
-        fi
-        GO_VERSION=$(echo "$GO_FULL" | cut -d. -f1,2)
-        echo "Detected Go version in go.mod: $GO_FULL -> go@$GO_VERSION"
-        echo "GO_VERSION=$GO_VERSION" >> "$GITHUB_ENV"
-
-    - name: Update Homebrew formula
-      run: |
-        formula_path="Formula/defang.rb"
-        sed -i.bak "s|url \".*|url \"$TARBALL_URL\"|g" $formula_path
-        sed -i.bak "s|sha256 \".*|sha256 \"$SHA256\"|g" $formula_path
-        sed -i.bak "s|depends_on \"go@[^\"]*\" => :build|depends_on \"go@$GO_VERSION\" => :build|g" $formula_path
-
-    - name: Commit and push changes
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git add Formula/defang.rb
-        git commit -m "Update Homebrew formula to version $TAG_NAME"
-        git push
-        git tag "$TAG_NAME"
-        git push --tags
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Notify Slack of Action Failures
-      if: ${{ failure() && github.ref_name == 'main' }}
-      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
-      env:
-        SLACK_TITLE: Defang Homebrew update workflow failed
-        MSG_MINIMAL: actions url
-        SLACK_WEBHOOK: ${{ secrets.SLACK_NOTIFIER_WEBHOOK_URL }}
+      - name: Notify Slack of Action Failures
+        if: ${{ failure() && github.ref_name == 'main' }}
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
+        env:
+          SLACK_TITLE: Defang Homebrew update workflow failed
+          MSG_MINIMAL: actions url
+          SLACK_WEBHOOK: ${{ secrets.SLACK_NOTIFIER_WEBHOOK_URL }}

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -60,7 +60,11 @@ jobs:
 
     - name: Compute SHA256 checksum
       run: |
-        SHA256=$(curl -L "$TARBALL_URL" | sha256sum | awk '{print $1}')
+        SHA256=$(curl -fsSL "$TARBALL_URL" | sha256sum | awk '{print $1}')
+        if [ -z "$SHA256" ]; then
+          echo "Failed to compute SHA256 for $TARBALL_URL" >&2
+          exit 1
+        fi
         echo "SHA256=$SHA256" >> "$GITHUB_ENV"
 
     - name: Determine required Go version from go.mod

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -14,13 +14,16 @@ jobs:
     steps:
 
     - name: Only deploy on repository_dispatch if version starts with 'v'
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        EVENT_ACTION: ${{ github.event.action }}
+        VERSION: ${{ github.event.client_payload.version }}
       run: |
-        echo "Event name: ${{ github.event_name }}"
-        echo "Type: ${{ github.event.action }}"
-        echo "Version: ${{ github.event.client_payload.version }}"
-        if [[ "${{ github.event_name }}" == "repository_dispatch" && "${{ github.event.action }}" == "update-homebrew-formula" ]]; then
-          echo "Version: ${{ github.event.client_payload.version }}"
-          if [[ "${{ github.event.client_payload.version }}" != v* ]]; then
+        echo "Event name: $EVENT_NAME"
+        echo "Type: $EVENT_ACTION"
+        echo "Version: $VERSION"
+        if [[ "$EVENT_NAME" == "repository_dispatch" && "$EVENT_ACTION" == "update-homebrew-formula" ]]; then
+          if [[ "$VERSION" != v* ]]; then
             echo "Version does not start with 'v'. Stopping workflow."
             exit 1
           fi
@@ -46,17 +49,19 @@ jobs:
         result-encoding: json
 
     - name: Set environment variables for latest release
+      env:
+        LATEST_RELEASE: ${{ steps.latest-release.outputs.result }}
       run: |
         # [WORKAROUND] Even though the github-script output is supposed to be JSON, looks like we are getting a string
-        TAG_NAME=$(echo '${{ steps.latest-release.outputs.result }}' | jq -r '.tag_name')
-        echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+        TAG_NAME=$(echo "$LATEST_RELEASE" | jq -r '.tag_name')
+        echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_ENV"
         # Fixes FormulaAudit/Urls: Use /archive/ URLs for GitHub tarballs
-        echo "TARBALL_URL=https://github.com/DefangLabs/defang/archive/refs/tags/$TAG_NAME.tar.gz" >> $GITHUB_ENV
+        echo "TARBALL_URL=https://github.com/DefangLabs/defang/archive/refs/tags/$TAG_NAME.tar.gz" >> "$GITHUB_ENV"
 
     - name: Compute SHA256 checksum
       run: |
-        SHA256=$(curl -L $TARBALL_URL | sha256sum | awk '{print $1}')
-        echo "SHA256=$SHA256" >> $GITHUB_ENV
+        SHA256=$(curl -L "$TARBALL_URL" | sha256sum | awk '{print $1}')
+        echo "SHA256=$SHA256" >> "$GITHUB_ENV"
 
     - name: Determine required Go version from go.mod
       run: |
@@ -68,7 +73,7 @@ jobs:
         fi
         GO_VERSION=$(echo "$GO_FULL" | cut -d. -f1,2)
         echo "Detected Go version in go.mod: $GO_FULL -> go@$GO_VERSION"
-        echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
+        echo "GO_VERSION=$GO_VERSION" >> "$GITHUB_ENV"
 
     - name: Update Homebrew formula
       run: |

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -92,10 +92,16 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add Formula/defang.rb
+          if git diff --cached --quiet; then
+            echo "Formula already up to date"
+            exit 0
+          fi
           git commit -m "Update Homebrew formula to version $TAG_NAME"
           git push
-          git tag "$TAG_NAME"
-          git push --tags
+          if ! git ls-remote --exit-code --tags origin "refs/tags/$TAG_NAME" >/dev/null 2>&1; then
+            git tag "$TAG_NAME"
+            git push origin "refs/tags/$TAG_NAME"
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -28,11 +28,11 @@ jobs:
       shell: bash
 
     - name: Checkout Homebrew repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Fetch the latest release from CLI repository
       id: latest-release
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
         script: |
           const { data } = await github.rest.repos.getLatestRelease({
@@ -58,11 +58,24 @@ jobs:
         SHA256=$(curl -L $TARBALL_URL | sha256sum | awk '{print $1}')
         echo "SHA256=$SHA256" >> $GITHUB_ENV
 
+    - name: Determine required Go version from go.mod
+      run: |
+        GO_MOD_URL="https://raw.githubusercontent.com/DefangLabs/defang/$TAG_NAME/src/go.mod"
+        GO_FULL=$(curl -fsSL "$GO_MOD_URL" | awk '/^go [0-9]/{print $2; exit}')
+        if [ -z "$GO_FULL" ]; then
+          echo "Failed to parse Go version from $GO_MOD_URL" >&2
+          exit 1
+        fi
+        GO_VERSION=$(echo "$GO_FULL" | cut -d. -f1,2)
+        echo "Detected Go version in go.mod: $GO_FULL -> go@$GO_VERSION"
+        echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
+
     - name: Update Homebrew formula
       run: |
         formula_path="Formula/defang.rb"
         sed -i.bak "s|url \".*|url \"$TARBALL_URL\"|g" $formula_path
         sed -i.bak "s|sha256 \".*|sha256 \"$SHA256\"|g" $formula_path
+        sed -i.bak "s|depends_on \"go@[^\"]*\" => :build|depends_on \"go@$GO_VERSION\" => :build|g" $formula_path
 
     - name: Commit and push changes
       run: |
@@ -78,7 +91,7 @@ jobs:
 
     - name: Notify Slack of Action Failures
       if: ${{ failure() && github.ref_name == 'main' }}
-      uses: rtCamp/action-slack-notify@v2
+      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
       env:
         SLACK_TITLE: Defang Homebrew update workflow failed
         MSG_MINIMAL: actions url

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -12,96 +12,97 @@ jobs:
   update-formula:
     runs-on: ubuntu-latest
     steps:
+      - name: Only deploy on repository_dispatch if version starts with 'v'
+        env:
+          EVENT_ACTION: ${{ github.event.action }}
+          EVENT_NAME: ${{ github.event_name }}
+          VERSION: ${{ github.event.client_payload.version }}
+        run: |
+          echo "Event name: $EVENT_NAME"
+          echo "Type: $EVENT_ACTION"
+          echo "Version: $VERSION"
+          if [[ "$EVENT_NAME" == "repository_dispatch" && "$EVENT_ACTION" == "update-homebrew-formula" ]]; then
+            if [[ "$VERSION" != v* ]]; then
+              echo "Version does not start with 'v'. Stopping workflow."
+              exit 1
+            fi
+          fi
+        shell: bash
 
-    - name: Only deploy on repository_dispatch if version starts with 'v'
-      env:
-        EVENT_ACTION: ${{ github.event.action }}
-        EVENT_NAME: ${{ github.event_name }}
-        VERSION: ${{ github.event.client_payload.version }}
-      run: |
-        echo "Event name: $EVENT_NAME"
-        echo "Type: $EVENT_ACTION"
-        echo "Version: $VERSION"
-        if [[ "$EVENT_NAME" == "repository_dispatch" && "$EVENT_ACTION" == "update-homebrew-formula" ]]; then
-          if [[ "$VERSION" != v* ]]; then
-            echo "Version does not start with 'v'. Stopping workflow."
+      - name: Checkout Homebrew repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Fetch the latest release from CLI repository
+        id: latest-release
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          script: |
+            const { data } = await github.rest.repos.getLatestRelease({
+              owner: process.env.GITHUB_REPOSITORY_OWNER,
+              repo: 'defang'
+            });
+            return {
+              tag_name: data.tag_name,
+              tarball_url: data.tarball_url
+            };
+          result-encoding: json
+
+      - name: Set environment variables for latest release
+        env:
+          RELEASE: ${{ steps.latest-release.outputs.result }}
+        run: |
+          # [WORKAROUND] Even though the github-script output is supposed to be JSON, looks like we are getting a string
+          TAG_NAME=$(jq -r '.tag_name' <<< "$RELEASE")
+          echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_ENV"
+          # Fixes FormulaAudit/Urls: Use /archive/ URLs for GitHub tarballs
+          echo "TARBALL_URL=https://github.com/DefangLabs/defang/archive/refs/tags/$TAG_NAME.tar.gz" >> "$GITHUB_ENV"
+
+      - name: Compute SHA256 checksum
+        run: |
+          set -o pipefail
+          SHA256=$(curl -fsSL "$TARBALL_URL" | sha256sum | awk '{print $1}')
+          if [ -z "$SHA256" ]; then
+            echo "Failed to compute SHA256 for $TARBALL_URL" >&2
             exit 1
           fi
-        fi
-      shell: bash
+          echo "SHA256=$SHA256" >> "$GITHUB_ENV"
 
-    - name: Checkout Homebrew repository
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Determine required Go version from go.mod
+        run: |
+          set -o pipefail
+          GO_MOD_URL="https://raw.githubusercontent.com/DefangLabs/defang/$TAG_NAME/src/go.mod"
+          GO_FULL=$(curl -fsSL "$GO_MOD_URL" | awk '/^go [0-9]/{print $2; exit}')
+          if [ -z "$GO_FULL" ]; then
+            echo "Failed to parse Go version from $GO_MOD_URL" >&2
+            exit 1
+          fi
+          GO_VERSION=$(echo "$GO_FULL" | cut -d. -f1,2)
+          echo "Detected Go version in go.mod: $GO_FULL -> go@$GO_VERSION"
+          echo "GO_VERSION=$GO_VERSION" >> "$GITHUB_ENV"
 
-    - name: Fetch the latest release from CLI repository
-      id: latest-release
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
-      with:
-        script: |
-          const { data } = await github.rest.repos.getLatestRelease({
-            owner: process.env.GITHUB_REPOSITORY_OWNER,
-            repo: 'defang'
-            });
-          return {
-            tag_name: data.tag_name,
-            tarball_url: data.tarball_url
-          };
-        result-encoding: json
+      - name: Update Homebrew formula
+        run: |
+          formula_path="Formula/defang.rb"
+          sed -i.bak "s|url \".*|url \"$TARBALL_URL\"|g" "$formula_path"
+          sed -i.bak "s|sha256 \".*|sha256 \"$SHA256\"|g" "$formula_path"
+          sed -i.bak "s|depends_on \"go@[^\"]*\" => :build|depends_on \"go@$GO_VERSION\" => :build|g" "$formula_path"
 
-    - name: Set environment variables for latest release
-      env:
-        RELEASE: ${{ steps.latest-release.outputs.result }}
-      run: |
-        # [WORKAROUND] Even though the github-script output is supposed to be JSON, looks like we are getting a string
-        TAG_NAME=$(jq -r '.tag_name' <<< "$RELEASE")
-        echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_ENV"
-        # Fixes FormulaAudit/Urls: Use /archive/ URLs for GitHub tarballs
-        echo "TARBALL_URL=https://github.com/DefangLabs/defang/archive/refs/tags/$TAG_NAME.tar.gz" >> "$GITHUB_ENV"
+      - name: Commit and push changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add Formula/defang.rb
+          git commit -m "Update Homebrew formula to version $TAG_NAME"
+          git push
+          git tag "$TAG_NAME"
+          git push --tags
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Compute SHA256 checksum
-      run: |
-        SHA256=$(curl -fsSL "$TARBALL_URL" | sha256sum | awk '{print $1}')
-        if [ -z "$SHA256" ]; then
-          echo "Failed to compute SHA256 for $TARBALL_URL" >&2
-          exit 1
-        fi
-        echo "SHA256=$SHA256" >> "$GITHUB_ENV"
-
-    - name: Determine required Go version from go.mod
-      run: |
-        GO_MOD_URL="https://raw.githubusercontent.com/DefangLabs/defang/$TAG_NAME/src/go.mod"
-        GO_FULL=$(curl -fsSL "$GO_MOD_URL" | awk '/^go [0-9]/{print $2; exit}')
-        if [ -z "$GO_FULL" ]; then
-          echo "Failed to parse Go version from $GO_MOD_URL" >&2
-          exit 1
-        fi
-        GO_VERSION=$(echo "$GO_FULL" | cut -d. -f1,2)
-        echo "Detected Go version in go.mod: $GO_FULL -> go@$GO_VERSION"
-        echo "GO_VERSION=$GO_VERSION" >> "$GITHUB_ENV"
-
-    - name: Update Homebrew formula
-      run: |
-        formula_path="Formula/defang.rb"
-        sed -i.bak "s|url \".*|url \"$TARBALL_URL\"|g" "$formula_path"
-        sed -i.bak "s|sha256 \".*|sha256 \"$SHA256\"|g" "$formula_path"
-        sed -i.bak "s|depends_on \"go@[^\"]*\" => :build|depends_on \"go@$GO_VERSION\" => :build|g" "$formula_path"
-
-    - name: Commit and push changes
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git add Formula/defang.rb
-        git commit -m "Update Homebrew formula to version $TAG_NAME"
-        git push
-        git tag "$TAG_NAME"
-        git push --tags
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Notify Slack of Action Failures
-      if: ${{ failure() && github.ref_name == 'main' }}
-      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
-      env:
-        SLACK_TITLE: Defang Homebrew update workflow failed
-        MSG_MINIMAL: actions url
-        SLACK_WEBHOOK: ${{ secrets.SLACK_NOTIFIER_WEBHOOK_URL }}
+      - name: Notify Slack of Action Failures
+        if: ${{ failure() && github.ref_name == 'main' }}
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
+        env:
+          SLACK_TITLE: Defang Homebrew update workflow failed
+          MSG_MINIMAL: actions url
+          SLACK_WEBHOOK: ${{ secrets.SLACK_NOTIFIER_WEBHOOK_URL }}

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -94,10 +94,10 @@ jobs:
           git add Formula/defang.rb
           if git diff --cached --quiet; then
             echo "Formula already up to date"
-            exit 0
+          else
+            git commit -m "Update Homebrew formula to version $TAG_NAME"
+            git push
           fi
-          git commit -m "Update Homebrew formula to version $TAG_NAME"
-          git push
           if ! git ls-remote --exit-code --tags origin "refs/tags/$TAG_NAME" >/dev/null 2>&1; then
             git tag "$TAG_NAME"
             git push origin "refs/tags/$TAG_NAME"

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -23,7 +23,6 @@ jobs:
         echo "Type: $EVENT_ACTION"
         echo "Version: $VERSION"
         if [[ "$EVENT_NAME" == "repository_dispatch" && "$EVENT_ACTION" == "update-homebrew-formula" ]]; then
-          echo "Version: $VERSION"
           if [[ "$VERSION" != v* ]]; then
             echo "Version does not start with 'v'. Stopping workflow."
             exit 1
@@ -74,7 +73,7 @@ jobs:
         fi
         GO_VERSION=$(echo "$GO_FULL" | cut -d. -f1,2)
         echo "Detected Go version in go.mod: $GO_FULL -> go@$GO_VERSION"
-        echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
+        echo "GO_VERSION=$GO_VERSION" >> "$GITHUB_ENV"
 
     - name: Update Homebrew formula
       run: |

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -32,11 +32,11 @@ jobs:
       shell: bash
 
     - name: Checkout Homebrew repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Fetch the latest release from CLI repository
       id: latest-release
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
         script: |
           const { data } = await github.rest.repos.getLatestRelease({
@@ -64,11 +64,24 @@ jobs:
         SHA256=$(curl -L "$TARBALL_URL" | sha256sum | awk '{print $1}')
         echo "SHA256=$SHA256" >> "$GITHUB_ENV"
 
+    - name: Determine required Go version from go.mod
+      run: |
+        GO_MOD_URL="https://raw.githubusercontent.com/DefangLabs/defang/$TAG_NAME/src/go.mod"
+        GO_FULL=$(curl -fsSL "$GO_MOD_URL" | awk '/^go [0-9]/{print $2; exit}')
+        if [ -z "$GO_FULL" ]; then
+          echo "Failed to parse Go version from $GO_MOD_URL" >&2
+          exit 1
+        fi
+        GO_VERSION=$(echo "$GO_FULL" | cut -d. -f1,2)
+        echo "Detected Go version in go.mod: $GO_FULL -> go@$GO_VERSION"
+        echo "GO_VERSION=$GO_VERSION" >> $GITHUB_ENV
+
     - name: Update Homebrew formula
       run: |
         formula_path="Formula/defang.rb"
         sed -i.bak "s|url \".*|url \"$TARBALL_URL\"|g" "$formula_path"
         sed -i.bak "s|sha256 \".*|sha256 \"$SHA256\"|g" "$formula_path"
+        sed -i.bak "s|depends_on \"go@[^\"]*\" => :build|depends_on \"go@$GO_VERSION\" => :build|g" "$formula_path"
 
     - name: Commit and push changes
       run: |
@@ -84,7 +97,7 @@ jobs:
 
     - name: Notify Slack of Action Failures
       if: ${{ failure() && github.ref_name == 'main' }}
-      uses: rtCamp/action-slack-notify@v2
+      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # v2.3.3
       env:
         SLACK_TITLE: Defang Homebrew update workflow failed
         MSG_MINIMAL: actions url


### PR DESCRIPTION
Supersedes #6 by getting Go ver from `go.mod`. 

The file `actionlint-matcher.json` comes from the actionlint repo at [rhysd/actionlint@main/.github/actionlint-matcher.json (raw)](https://raw.githubusercontent.com/rhysd/actionlint/main/.github/actionlint-matcher.json). See [rhysd/actionlint@v1.7.12/docs/usage.md#problem-matchers](https://github.com/rhysd/actionlint/blob/v1.7.12/docs/usage.md?rgh-link-date=2026-05-25T18%3A42%3A37Z#problem-matchers)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened CI: pinned actions, improved quoting, safer branch deletion, and expanded macOS test matrix.
  * Strengthened release/update flow with extra validations and checksum verification.

* **New Features**
  * Pre-commit hook to run action linting when workflow/action files change.
  * Added an actionlint problem matcher.
  * New CI job to lint GitHub Actions and fail on unpinned action usages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DefangLabs/homebrew-defang/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->