### PR TITLE
ci: auto-merge Dependabot updates

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,36 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ github.token }}
           HOMEBREW_GITHUB_PACKAGES_USER: ${{ github.actor }}
           PULL_REQUEST: ${{ github.event.pull_request.number }}
-        run: brew pr-pull --debug --tap=$GITHUB_REPOSITORY $PULL_REQUEST
+        run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
@@ -36,4 +36,4 @@ jobs:
         if: github.event.pull_request.head.repo.fork == false
         env:
           BRANCH: ${{ github.event.pull_request.head.ref }}
-        run: git push --delete origin $BRANCH
+        run: git push --delete origin "$BRANCH"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
 
       - name: Set up git
-        uses: Homebrew/actions/git-user-config@master
+        uses: Homebrew/actions/git-user-config@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
 
       - name: Pull bottles
         env:
@@ -27,7 +27,7 @@ jobs:
         run: brew pr-pull --debug --tap="$GITHUB_REPOSITORY" "$PULL_REQUEST"
 
       - name: Push commits
-        uses: Homebrew/actions/git-try-push@master
+        uses: Homebrew/actions/git-try-push@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
         with:
           token: ${{ github.token }}
           branch: main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: bottles
           path: '*.bottle.*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,12 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-13]
+        os: [ubuntu-24.04, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@1f8e202ffddf94def7f42f6fa3a482e821489f9c # 2026.07.10.1
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13]
+        os: [ubuntu-24.04, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -14,13 +14,17 @@ jobs:
     steps:
 
     - name: Only deploy on repository_dispatch if version starts with 'v'
+      env:
+        EVENT_ACTION: ${{ github.event.action }}
+        EVENT_NAME: ${{ github.event_name }}
+        VERSION: ${{ github.event.client_payload.version }}
       run: |
-        echo "Event name: ${{ github.event_name }}"
-        echo "Type: ${{ github.event.action }}"
-        echo "Version: ${{ github.event.client_payload.version }}"
-        if [[ "${{ github.event_name }}" == "repository_dispatch" && "${{ github.event.action }}" == "update-homebrew-formula" ]]; then
-          echo "Version: ${{ github.event.client_payload.version }}"
-          if [[ "${{ github.event.client_payload.version }}" != v* ]]; then
+        echo "Event name: $EVENT_NAME"
+        echo "Type: $EVENT_ACTION"
+        echo "Version: $VERSION"
+        if [[ "$EVENT_NAME" == "repository_dispatch" && "$EVENT_ACTION" == "update-homebrew-formula" ]]; then
+          echo "Version: $VERSION"
+          if [[ "$VERSION" != v* ]]; then
             echo "Version does not start with 'v'. Stopping workflow."
             exit 1
           fi
@@ -46,23 +50,25 @@ jobs:
         result-encoding: json
 
     - name: Set environment variables for latest release
+      env:
+        RELEASE: ${{ steps.latest-release.outputs.result }}
       run: |
         # [WORKAROUND] Even though the github-script output is supposed to be JSON, looks like we are getting a string
-        TAG_NAME=$(echo '${{ steps.latest-release.outputs.result }}' | jq -r '.tag_name')
-        echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+        TAG_NAME=$(jq -r '.tag_name' <<< "$RELEASE")
+        echo "TAG_NAME=$TAG_NAME" >> "$GITHUB_ENV"
         # Fixes FormulaAudit/Urls: Use /archive/ URLs for GitHub tarballs
-        echo "TARBALL_URL=https://github.com/DefangLabs/defang/archive/refs/tags/$TAG_NAME.tar.gz" >> $GITHUB_ENV
+        echo "TARBALL_URL=https://github.com/DefangLabs/defang/archive/refs/tags/$TAG_NAME.tar.gz" >> "$GITHUB_ENV"
 
     - name: Compute SHA256 checksum
       run: |
-        SHA256=$(curl -L $TARBALL_URL | sha256sum | awk '{print $1}')
-        echo "SHA256=$SHA256" >> $GITHUB_ENV
+        SHA256=$(curl -L "$TARBALL_URL" | sha256sum | awk '{print $1}')
+        echo "SHA256=$SHA256" >> "$GITHUB_ENV"
 
     - name: Update Homebrew formula
       run: |
         formula_path="Formula/defang.rb"
-        sed -i.bak "s|url \".*|url \"$TARBALL_URL\"|g" $formula_path
-        sed -i.bak "s|sha256 \".*|sha256 \"$SHA256\"|g" $formula_path
+        sed -i.bak "s|url \".*|url \"$TARBALL_URL\"|g" "$formula_path"
+        sed -i.bak "s|sha256 \".*|sha256 \"$SHA256\"|g" "$formula_path"
 
     - name: Commit and push changes
       run: |


### PR DESCRIPTION
## Summary

- approve Dependabot patch and minor version updates
- enable squash auto-merge after required checks pass
- leave major updates for manual review