### PR TITLE
Fix SIGPIPE race in go.mod Go-version parsing

### DIFF
--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -69,9 +69,9 @@ jobs:
 
       - name: Determine required Go version from go.mod
         run: |
-          set -o pipefail
           GO_MOD_URL="https://raw.githubusercontent.com/DefangLabs/defang/$TAG_NAME/src/go.mod"
-          GO_FULL=$(curl -fsSL "$GO_MOD_URL" | awk '/^go [0-9]/{print $2; exit}')
+          GO_MOD=$(curl -fsSL "$GO_MOD_URL")
+          GO_FULL=$(awk '/^go [0-9]/{print $2; exit}' <<< "$GO_MOD")
           if [ -z "$GO_FULL" ]; then
             echo "Failed to parse Go version from $GO_MOD_URL" >&2
             exit 1


### PR DESCRIPTION
## Summary
- The "Update Homebrew Formula" workflow started failing on run [32432417340](https://github.com/DefangLabs/homebrew-defang/actions/runs/32432417340) (and again on rerun) at the "Determine required Go version from go.mod" step, with `curl` exiting 23 ("failed writing received data").
- Root cause: `curl -fsSL "$GO_MOD_URL" | awk '/^go [0-9]/{print $2; exit}'` — the `go X.Y` line sits near the top of `go.mod`, so `awk` matches almost immediately and its `exit` closes the pipe's read end while `curl` may still be writing the rest of the (now larger, dependency-heavy) response body. That's a SIGPIPE race: `curl` gets a write error and returns 23, which `set -o pipefail` turns into a step failure. This explains why it worked for months and only recently started failing — `go.mod` grew enough that `curl` now issues multiple writes, widening the race window.
- Fix: capture curl's full output into a variable first, then run `awk` over it. This removes the pipe entirely so parsing never races the download.

## Test plan
- [x] Ran the fixed snippet locally against the real URL (`v3.14.0/src/go.mod`) — correctly resolves `GO_FULL=1.25.9`.
- [ ] Confirm the workflow succeeds end-to-end on a real `repository_dispatch` (or manual `workflow_dispatch`) run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)